### PR TITLE
Feature 199 metaform metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,7 +108,7 @@ val generateApiSpec = tasks.register("generateApiSpec",GenerateTask::class){
     this.configOptions.put("library", "jaxrs-spec")
     this.configOptions.put("dateLibrary", "java8")
     this.configOptions.put("interfaceOnly", "true")
-    this.configOptions.put("useCoroutines", "true")
+    this.configOptions.put("useCoroutines", "false")
     this.configOptions.put("enumPropertyNaming", "UPPERCASE")
     this.configOptions.put("returnResponse", "true")
     this.configOptions.put("useSwaggerAnnotations", "false")

--- a/src/main/kotlin/fi/metatavu/metaform/server/controllers/MetaformController.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/controllers/MetaformController.kt
@@ -137,13 +137,13 @@ class MetaformController {
      * @return Updated Metaform
      */
     fun updateMetaform(
-            metaform: Metaform,
-            exportTheme: ExportTheme?,
-            visibility: MetaformVisibility,
-            data: String,
-            allowAnonymous: Boolean?,
-            slug: String?,
-            lastModifierId: UUID
+        metaform: Metaform,
+        exportTheme: ExportTheme?,
+        visibility: MetaformVisibility,
+        data: String,
+        allowAnonymous: Boolean?,
+        slug: String?,
+        lastModifierId: UUID
     ): Metaform {
         metaformDAO.updateData(metaform, data, lastModifierId)
         metaformDAO.updateAllowAnonymous(metaform, allowAnonymous, lastModifierId)

--- a/src/main/kotlin/fi/metatavu/metaform/server/controllers/MetaformController.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/controllers/MetaformController.kt
@@ -69,6 +69,7 @@ class MetaformController {
      * @param allowAnonymous allow anonymous
      * @param title title
      * @param data form JSON
+     * @param creatorId creator id
      * @return Metaform
      */
     fun createMetaform(
@@ -77,7 +78,8 @@ class MetaformController {
             visibility: MetaformVisibility,
             title: String?,
             slug: String? = null,
-            data: String
+            data: String,
+            creatorId: UUID
     ): Metaform {
         return metaformDAO.create(
             id = UUID.randomUUID(),
@@ -85,7 +87,9 @@ class MetaformController {
             exportTheme = exportTheme,
             visibility = visibility,
             allowAnonymous = allowAnonymous,
-            data = data
+            data = data,
+            creatorId = creatorId,
+            lastModifierId = creatorId
         ).let {
             keycloakController.createMetaformManagementGroup(it.id!!)
             it
@@ -129,6 +133,7 @@ class MetaformController {
      * @param data form JSON
      * @param allowAnonymous allow anonymous
      * @param slug slug
+     * @param lastModifierId last modifier id
      * @return Updated Metaform
      */
     fun updateMetaform(
@@ -137,13 +142,14 @@ class MetaformController {
             visibility: MetaformVisibility,
             data: String,
             allowAnonymous: Boolean?,
-            slug: String?
+            slug: String?,
+            lastModifierId: UUID
     ): Metaform {
-        metaformDAO.updateData(metaform, data)
-        metaformDAO.updateAllowAnonymous(metaform, allowAnonymous)
-        metaformDAO.updateExportTheme(metaform, exportTheme)
-        metaformDAO.updateSlug(metaform, slug ?: metaform.slug)
-        metaformDAO.updateVisibility(metaform, visibility)
+        metaformDAO.updateData(metaform, data, lastModifierId)
+        metaformDAO.updateAllowAnonymous(metaform, allowAnonymous, lastModifierId)
+        metaformDAO.updateExportTheme(metaform, exportTheme, lastModifierId)
+        metaformDAO.updateSlug(metaform, slug ?: metaform.slug, lastModifierId)
+        metaformDAO.updateVisibility(metaform, visibility, lastModifierId)
         return metaform
     }
 

--- a/src/main/kotlin/fi/metatavu/metaform/server/controllers/MetaformController.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/controllers/MetaformController.kt
@@ -2,6 +2,7 @@ package fi.metatavu.metaform.server.controllers
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.github.slugify.Slugify
 import fi.metatavu.metaform.api.spec.model.MetaformField
 import fi.metatavu.metaform.api.spec.model.MetaformVisibility
@@ -88,8 +89,7 @@ class MetaformController {
             visibility = visibility,
             allowAnonymous = allowAnonymous,
             data = data,
-            creatorId = creatorId,
-            lastModifierId = creatorId
+            creatorId = creatorId
         ).let {
             keycloakController.createMetaformManagementGroup(it.id!!)
             it
@@ -181,6 +181,8 @@ class MetaformController {
     @Throws(MalformedMetaformJsonException::class)
     fun serializeMetaform(metaform: fi.metatavu.metaform.api.spec.model.Metaform): String {
         val objectMapper = ObjectMapper()
+        objectMapper.registerModule(JavaTimeModule())
+
         try {
             return objectMapper.writeValueAsString(metaform)
         } catch (e: JsonProcessingException) {

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/dao/MetaformDAO.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/dao/MetaformDAO.kt
@@ -25,6 +25,8 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    * @param exportTheme export theme
    * @param allowAnonymous whether to allow anonymous repliers
    * @param data form JSON
+   * @param creatorId creator id
+   * @param lastModifierId last modifier id
    * @return created Metaform
    */
   fun create(
@@ -33,7 +35,9 @@ class MetaformDAO : AbstractDAO<Metaform>() {
     exportTheme: ExportTheme?,
     visibility: MetaformVisibility,
     allowAnonymous: Boolean?,
-    data: String
+    data: String,
+    creatorId: UUID,
+    lastModifierId: UUID
   ): Metaform {
     val metaform = Metaform()
     metaform.id = id
@@ -42,6 +46,7 @@ class MetaformDAO : AbstractDAO<Metaform>() {
     metaform.data = data
     metaform.slug = slug
     metaform.allowAnonymous = allowAnonymous
+    metaform.creatorId = creatorId
     return persist(metaform)
   }
 
@@ -69,10 +74,12 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    *
    * @param metaform Metaform
    * @param data form JSON
+   * @param lastModifierId last modifier id
    * @return Updated Metaform
    */
-  fun updateData(metaform: Metaform, data: String): Metaform {
+  fun updateData(metaform: Metaform, data: String, lastModifierId: UUID): Metaform {
     metaform.data = data
+    metaform.lastModifierId = lastModifierId
     return persist(metaform)
   }
 
@@ -81,10 +88,12 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    *
    * @param metaform Metaform
    * @param allowAnonymous allow anonymous
+   * @param lastModifierId last modifier id
    * @return Updated Metaform
    */
-  fun updateAllowAnonymous(metaform: Metaform, allowAnonymous: Boolean?): Metaform {
+  fun updateAllowAnonymous(metaform: Metaform, allowAnonymous: Boolean?, lastModifierId: UUID): Metaform {
     metaform.allowAnonymous = allowAnonymous
+    metaform.lastModifierId = lastModifierId
     return persist(metaform)
   }
 
@@ -93,10 +102,12 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    *
    * @param metaform Metaform
    * @param exportTheme export theme
+   * @param lastModifierId last modifier id
    * @return Updated Metaform
    */
-  fun updateExportTheme(metaform: Metaform, exportTheme: ExportTheme?): Metaform {
+  fun updateExportTheme(metaform: Metaform, exportTheme: ExportTheme?, lastModifierId: UUID): Metaform {
     metaform.exportTheme = exportTheme
+    metaform.lastModifierId = lastModifierId
     return persist(metaform)
   }
 
@@ -105,10 +116,12 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    *
    * @param metaform Metaform
    * @param visibility visibility
+   * @param lastModifierId last modifier id
    * @return Updated Metaform
    */
-  fun updateVisibility(metaform: Metaform, visibility: MetaformVisibility): Metaform {
+  fun updateVisibility(metaform: Metaform, visibility: MetaformVisibility, lastModifierId: UUID): Metaform {
     metaform.visibility = visibility
+    metaform.lastModifierId = lastModifierId
     return persist(metaform)
   }
 
@@ -117,10 +130,12 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    *
    * @param metaform Metaform
    * @param slug slug
+   * @param lastModifierId last modifier id
    * @return Updated Metaform
    */
-  fun updateSlug(metaform: Metaform, slug: String): Metaform {
+  fun updateSlug(metaform: Metaform, slug: String, lastModifierId: UUID): Metaform {
     metaform.slug = slug
+    metaform.lastModifierId = lastModifierId
     return persist(metaform)
   }
 

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/dao/MetaformDAO.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/dao/MetaformDAO.kt
@@ -4,6 +4,7 @@ import fi.metatavu.metaform.api.spec.model.MetaformVisibility
 import fi.metatavu.metaform.server.persistence.model.ExportTheme
 import fi.metatavu.metaform.server.persistence.model.Metaform
 import fi.metatavu.metaform.server.persistence.model.Metaform_
+import java.time.OffsetDateTime
 import java.util.*
 import javax.enterprise.context.ApplicationScoped
 import javax.persistence.criteria.CriteriaBuilder
@@ -26,7 +27,6 @@ class MetaformDAO : AbstractDAO<Metaform>() {
    * @param allowAnonymous whether to allow anonymous repliers
    * @param data form JSON
    * @param creatorId creator id
-   * @param lastModifierId last modifier id
    * @return created Metaform
    */
   fun create(
@@ -36,9 +36,9 @@ class MetaformDAO : AbstractDAO<Metaform>() {
     visibility: MetaformVisibility,
     allowAnonymous: Boolean?,
     data: String,
-    creatorId: UUID,
-    lastModifierId: UUID
+    creatorId: UUID
   ): Metaform {
+    val odtNow = OffsetDateTime.now()
     val metaform = Metaform()
     metaform.id = id
     metaform.exportTheme = exportTheme
@@ -46,7 +46,10 @@ class MetaformDAO : AbstractDAO<Metaform>() {
     metaform.data = data
     metaform.slug = slug
     metaform.allowAnonymous = allowAnonymous
+    metaform.createdAt = odtNow
+    metaform.modifiedAt = odtNow
     metaform.creatorId = creatorId
+    metaform.lastModifierId = creatorId
     return persist(metaform)
   }
 

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/dao/MetaformDAO.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/dao/MetaformDAO.kt
@@ -4,7 +4,6 @@ import fi.metatavu.metaform.api.spec.model.MetaformVisibility
 import fi.metatavu.metaform.server.persistence.model.ExportTheme
 import fi.metatavu.metaform.server.persistence.model.Metaform
 import fi.metatavu.metaform.server.persistence.model.Metaform_
-import java.time.OffsetDateTime
 import java.util.*
 import javax.enterprise.context.ApplicationScoped
 import javax.persistence.criteria.CriteriaBuilder
@@ -38,7 +37,6 @@ class MetaformDAO : AbstractDAO<Metaform>() {
     data: String,
     creatorId: UUID
   ): Metaform {
-    val odtNow = OffsetDateTime.now()
     val metaform = Metaform()
     metaform.id = id
     metaform.exportTheme = exportTheme
@@ -46,8 +44,6 @@ class MetaformDAO : AbstractDAO<Metaform>() {
     metaform.data = data
     metaform.slug = slug
     metaform.allowAnonymous = allowAnonymous
-    metaform.createdAt = odtNow
-    metaform.modifiedAt = odtNow
     metaform.creatorId = creatorId
     metaform.lastModifierId = creatorId
     return persist(metaform)

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metadata.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metadata.kt
@@ -24,8 +24,9 @@ abstract class Metadata {
    */
   @PrePersist
   fun onCreate() {
-    createdAt = OffsetDateTime.now()
-    modifiedAt = OffsetDateTime.now()
+    val odtNow = OffsetDateTime.now()
+    createdAt = odtNow
+    modifiedAt = odtNow
   }
 
   /**
@@ -33,6 +34,7 @@ abstract class Metadata {
    */
   @PreUpdate
   fun onUpdate() {
+    println("preUpdate called")
     modifiedAt = OffsetDateTime.now()
   }
 

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metadata.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metadata.kt
@@ -1,7 +1,6 @@
 package fi.metatavu.metaform.server.persistence.model
 
 import java.time.OffsetDateTime
-import java.util.*
 import javax.persistence.Column
 import javax.persistence.MappedSuperclass
 import javax.persistence.PrePersist
@@ -14,10 +13,10 @@ import javax.persistence.PreUpdate
 abstract class Metadata {
 
   @Column(nullable = false)
-  open var createdAt: OffsetDateTime? = null
+  var createdAt: OffsetDateTime? = null
 
   @Column(nullable = false)
-  open var modifiedAt: OffsetDateTime? = null
+  var modifiedAt: OffsetDateTime? = null
 
   /**
    * JPA pre-persist event handler
@@ -34,7 +33,6 @@ abstract class Metadata {
    */
   @PreUpdate
   fun onUpdate() {
-    println("preUpdate called")
     modifiedAt = OffsetDateTime.now()
   }
 

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metadata.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metadata.kt
@@ -13,10 +13,10 @@ import javax.persistence.PreUpdate
 abstract class Metadata {
 
   @Column(nullable = false)
-  var createdAt: OffsetDateTime? = null
+  open var createdAt: OffsetDateTime? = null
 
   @Column(nullable = false)
-  var modifiedAt: OffsetDateTime? = null
+  open var modifiedAt: OffsetDateTime? = null
 
   /**
    * JPA pre-persist event handler

--- a/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metaform.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/persistence/model/Metaform.kt
@@ -17,7 +17,7 @@ import javax.validation.constraints.NotNull
 @Cacheable(true)
 @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["slug"])])
-class Metaform {
+class Metaform: Metadata() {
   @Id
   var id: UUID? = null
 
@@ -42,4 +42,10 @@ class Metaform {
 
   @ManyToOne
   var exportTheme: ExportTheme? = null
+
+  @Column(nullable = false)
+  lateinit var creatorId: UUID
+
+  @Column(nullable = false)
+  lateinit var lastModifierId: UUID
 }

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/AdminThemeApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/AdminThemeApi.kt
@@ -20,7 +20,7 @@ class AdminThemeApi : fi.metatavu.metaform.api.spec.AdminThemeApi, AbstractApi()
     @Inject
     lateinit var adminThemeTranslator: AdminThemeTranslator
 
-    override suspend fun createAdminTheme(adminTheme: AdminTheme): Response {
+    override fun createAdminTheme(adminTheme: AdminTheme): Response {
         val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
         if (!isRealmSystemAdmin) {
             return createForbidden(createNotAllowedMessage(CREATE, ADMIN_THEME))
@@ -57,7 +57,7 @@ class AdminThemeApi : fi.metatavu.metaform.api.spec.AdminThemeApi, AbstractApi()
         return createOk(translatedTheme)
     }
 
-    override suspend fun deleteAdminTheme(themeId: UUID): Response {
+    override fun deleteAdminTheme(themeId: UUID): Response {
         loggedUserId ?: return createForbidden(UNAUTHORIZED)
         if (!isRealmSystemAdmin) {
             return createForbidden(createNotAllowedMessage(CREATE, ADMIN_THEME))
@@ -68,7 +68,7 @@ class AdminThemeApi : fi.metatavu.metaform.api.spec.AdminThemeApi, AbstractApi()
         return createNoContent()
     }
 
-    override suspend fun findAdminTheme(themeId: UUID): Response {
+    override fun findAdminTheme(themeId: UUID): Response {
         loggedUserId ?: return createForbidden(UNAUTHORIZED)
         if (!isMetaformManagerAny) {
             return createForbidden(createNotAllowedMessage(CREATE, ADMIN_THEME))
@@ -84,7 +84,7 @@ class AdminThemeApi : fi.metatavu.metaform.api.spec.AdminThemeApi, AbstractApi()
         return createOk(translatedTheme)
     }
 
-    override suspend fun listAdminTheme(): Response {
+    override fun listAdminTheme(): Response {
         loggedUserId ?: return createForbidden(UNAUTHORIZED)
         if (!isRealmSystemAdmin) {
             return createForbidden(createNotAllowedMessage(CREATE, ADMIN_THEME))
@@ -99,7 +99,7 @@ class AdminThemeApi : fi.metatavu.metaform.api.spec.AdminThemeApi, AbstractApi()
         return createOk(translatedThemes)
     }
 
-    override suspend fun updateAdminTheme(themeId: UUID, adminTheme: AdminTheme): Response {
+    override fun updateAdminTheme(themeId: UUID, adminTheme: AdminTheme): Response {
         loggedUserId ?: return createForbidden(UNAUTHORIZED)
         if (!isRealmSystemAdmin) {
             return createForbidden(createNotAllowedMessage(CREATE, ADMIN_THEME))

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/AttachmentsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/AttachmentsApi.kt
@@ -20,7 +20,7 @@ class AttachmentsApi: fi.metatavu.metaform.api.spec.AttachmentsApi, AbstractApi(
   @Inject
   lateinit var attachmentTranslator: AttachmentTranslator
 
-  override suspend fun findAttachment(attachmentId: UUID, ownerKey: String?): Response {
+  override fun findAttachment(attachmentId: UUID, ownerKey: String?): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val attachment: Attachment = attachmentController.findAttachmentById(attachmentId)
@@ -45,7 +45,7 @@ class AttachmentsApi: fi.metatavu.metaform.api.spec.AttachmentsApi, AbstractApi(
     } else replyController.isValidOwnerKey(reply, ownerKey)
   }
 
-  override suspend fun findAttachmentData(attachmentId: UUID, ownerKey: String?): Response {
+  override fun findAttachmentData(attachmentId: UUID, ownerKey: String?): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
     val attachment: Attachment = attachmentController.findAttachmentById(attachmentId)
             ?: return createNotFound(createNotFoundMessage(ATTACHMENT, attachmentId))

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/AuditLogEntriesApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/AuditLogEntriesApi.kt
@@ -35,7 +35,7 @@ class AuditLogEntriesApi: fi.metatavu.metaform.api.spec.AuditLogEntriesApi, Abst
    * 
    * @return deleted audit log entry
    */
-  override suspend fun deleteAuditLogEntry(metaformId: UUID, auditLogEntryId: UUID): Response {
+  override fun deleteAuditLogEntry(metaformId: UUID, auditLogEntryId: UUID): Response {
     if (!systemSettingController.inTestMode()) {
       return createForbidden(createNotAllowedMessage(DELETE, AUDIT_LOG_ENTRY))
     }
@@ -59,7 +59,7 @@ class AuditLogEntriesApi: fi.metatavu.metaform.api.spec.AuditLogEntriesApi, Abst
    * @param createdAfter filter results created after this date
    * @return list of audit log entries
    */
-  override suspend fun listAuditLogEntries(
+  override fun listAuditLogEntries(
     metaformId: UUID,
     userId: UUID?,
     replyId: UUID?,

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/DraftsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/DraftsApi.kt
@@ -39,7 +39,7 @@ class DraftsApi: fi.metatavu.metaform.api.spec.DraftsApi, AbstractApi() {
    * @param draft Draft to create
    * @return Created draft
    */
-  override suspend fun createDraft(metaformId: UUID, draft: Draft): Response {
+  override fun createDraft(metaformId: UUID, draft: Draft): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val metaform: Metaform = metaformController.findMetaformById(metaformId)
@@ -76,7 +76,7 @@ class DraftsApi: fi.metatavu.metaform.api.spec.DraftsApi, AbstractApi() {
    * @param metaformId Metaform id
    * @param draftId Draft id
    */
-  override suspend fun deleteDraft(metaformId: UUID, draftId: UUID): Response {
+  override fun deleteDraft(metaformId: UUID, draftId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val metaform = metaformController.findMetaformById(metaformId)
@@ -116,7 +116,7 @@ class DraftsApi: fi.metatavu.metaform.api.spec.DraftsApi, AbstractApi() {
    * @param metaformId Metaform id
    * @param draftId Draft id
    */
-  override suspend fun findDraft(metaformId: UUID, draftId: UUID): Response {
+  override fun findDraft(metaformId: UUID, draftId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val metaform = metaformController.findMetaformById(metaformId)
@@ -158,7 +158,7 @@ class DraftsApi: fi.metatavu.metaform.api.spec.DraftsApi, AbstractApi() {
    * @param draftId Draft id
    * @param draft Draft data
    */
-  override suspend fun updateDraft(metaformId: UUID, draftId: UUID, draft: Draft): Response {
+  override fun updateDraft(metaformId: UUID, draftId: UUID, draft: Draft): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val metaform = metaformController.findMetaformById(metaformId)

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/EmailNotificationsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/EmailNotificationsApi.kt
@@ -31,7 +31,7 @@ class EmailNotificationsApi : fi.metatavu.metaform.api.spec.EmailNotificationsAp
    * @param metaformId Metaform id
    * @return List of email notifications
    */
-  override suspend fun listEmailNotifications(metaformId: UUID): Response {
+  override fun listEmailNotifications(metaformId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -53,7 +53,7 @@ class EmailNotificationsApi : fi.metatavu.metaform.api.spec.EmailNotificationsAp
    * @param emailNotification email notification
    * @return created email notification
    */
-  override suspend fun createEmailNotification(
+  override fun createEmailNotification(
     metaformId: UUID,
     emailNotification: EmailNotification
   ): Response {
@@ -89,7 +89,7 @@ class EmailNotificationsApi : fi.metatavu.metaform.api.spec.EmailNotificationsAp
    * @param emailNotificationId email notification id
    * @return deleted email notification
    */
-  override suspend fun deleteEmailNotification(
+  override fun deleteEmailNotification(
     metaformId: UUID,
     emailNotificationId: UUID
   ): Response {
@@ -121,7 +121,7 @@ class EmailNotificationsApi : fi.metatavu.metaform.api.spec.EmailNotificationsAp
    * @param emailNotificationId email notification id
    * @return email notification
    */
-  override suspend fun findEmailNotification(
+  override fun findEmailNotification(
     metaformId: UUID,
     emailNotificationId: UUID
   ): Response {
@@ -151,7 +151,7 @@ class EmailNotificationsApi : fi.metatavu.metaform.api.spec.EmailNotificationsAp
    * @param emailNotification email data
    * @return updated email notification
    */
-  override suspend fun updateEmailNotification(
+  override fun updateEmailNotification(
     metaformId: UUID,
     emailNotificationId: UUID,
     emailNotification: EmailNotification

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/ExportThemeFilesApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/ExportThemeFilesApi.kt
@@ -20,7 +20,7 @@ class ExportThemeFilesApi: fi.metatavu.metaform.api.spec.ExportThemeFilesApi, Ab
   @Inject
   lateinit var exportThemeTranslator: ExportThemeTranslator
 
-  override suspend fun createExportThemeFile(
+  override fun createExportThemeFile(
     exportThemeId: UUID,
     exportThemeFile: ExportThemeFile
   ): Response {
@@ -44,7 +44,7 @@ class ExportThemeFilesApi: fi.metatavu.metaform.api.spec.ExportThemeFilesApi, Ab
 
   }
 
-  override suspend fun deleteExportThemeFile(
+  override fun deleteExportThemeFile(
     exportThemeId: UUID,
     exportThemeFileId: UUID
   ): Response {
@@ -70,7 +70,7 @@ class ExportThemeFilesApi: fi.metatavu.metaform.api.spec.ExportThemeFilesApi, Ab
 
   }
 
-  override suspend fun findExportThemeFile(exportThemeId: UUID, exportThemeFileId: UUID): Response {
+  override fun findExportThemeFile(exportThemeId: UUID, exportThemeFileId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isRealmSystemAdmin) {
@@ -89,7 +89,7 @@ class ExportThemeFilesApi: fi.metatavu.metaform.api.spec.ExportThemeFilesApi, Ab
 
   }
 
-  override suspend fun listExportThemeFiles(exportThemeId: UUID): Response {
+  override fun listExportThemeFiles(exportThemeId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isRealmSystemAdmin) {
@@ -104,7 +104,7 @@ class ExportThemeFilesApi: fi.metatavu.metaform.api.spec.ExportThemeFilesApi, Ab
 
   }
 
-  override suspend fun updateExportThemeFile(
+  override fun updateExportThemeFile(
     exportThemeId: UUID,
     exportThemeFileId: UUID,
     exportThemeFile: ExportThemeFile

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/ExportThemesApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/ExportThemesApi.kt
@@ -19,7 +19,7 @@ class ExportThemesApi: fi.metatavu.metaform.api.spec.ExportThemesApi, AbstractAp
   @Inject
   lateinit var exportThemeTranslator: ExportThemeTranslator
 
-  override suspend fun createExportTheme(exportTheme: ExportTheme): Response {
+  override fun createExportTheme(exportTheme: ExportTheme): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isRealmSystemAdmin) {
@@ -41,7 +41,7 @@ class ExportThemesApi: fi.metatavu.metaform.api.spec.ExportThemesApi, AbstractAp
     return createOk(exportThemeTranslator.translateExportTheme(createdExportTheme))
   }
 
-  override suspend fun deleteExportTheme(exportThemeId: UUID): Response {
+  override fun deleteExportTheme(exportThemeId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isRealmSystemAdmin) {
@@ -56,7 +56,7 @@ class ExportThemesApi: fi.metatavu.metaform.api.spec.ExportThemesApi, AbstractAp
     return createNoContent()
   }
 
-  override suspend fun findExportTheme(exportThemeId: UUID): Response {
+  override fun findExportTheme(exportThemeId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isRealmSystemAdmin) {
@@ -69,7 +69,7 @@ class ExportThemesApi: fi.metatavu.metaform.api.spec.ExportThemesApi, AbstractAp
     return createOk(exportThemeTranslator.translateExportTheme(exportTheme))
   }
 
-  override suspend fun listExportThemes(): Response {
+  override fun listExportThemes(): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     return if (!isRealmSystemAdmin) {
@@ -78,7 +78,7 @@ class ExportThemesApi: fi.metatavu.metaform.api.spec.ExportThemesApi, AbstractAp
             .map(exportThemeTranslator::translateExportTheme))
   }
 
-  override suspend fun updateExportTheme(exportThemeId: UUID, exportTheme: ExportTheme): Response {
+  override fun updateExportTheme(exportThemeId: UUID, exportTheme: ExportTheme): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isRealmSystemAdmin) {

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformMemberGroupsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformMemberGroupsApi.kt
@@ -25,7 +25,7 @@ class MetaformMemberGroupsApi: fi.metatavu.metaform.api.spec.MetaformMemberGroup
   @Inject
   lateinit var permissionController: PermissionController
 
-  override suspend fun createMetaformMemberGroup(metaformId: UUID, metaformMemberGroup: MetaformMemberGroup): Response {
+  override fun createMetaformMemberGroup(metaformId: UUID, metaformMemberGroup: MetaformMemberGroup): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -59,7 +59,7 @@ class MetaformMemberGroupsApi: fi.metatavu.metaform.api.spec.MetaformMemberGroup
     return createOk(metaformMemberGroupTranslator.translate(createdGroup, metaformMemberGroup.memberIds))
   }
 
-  override suspend fun deleteMetaformMemberGroup(metaformId: UUID, metaformMemberGroupId: UUID): Response {
+  override fun deleteMetaformMemberGroup(metaformId: UUID, metaformMemberGroupId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -77,7 +77,7 @@ class MetaformMemberGroupsApi: fi.metatavu.metaform.api.spec.MetaformMemberGroup
     return createNoContent()
   }
 
-  override suspend fun findMetaformMemberGroup(metaformId: UUID, metaformMemberGroupId: UUID): Response {
+  override fun findMetaformMemberGroup(metaformId: UUID, metaformMemberGroupId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -94,7 +94,7 @@ class MetaformMemberGroupsApi: fi.metatavu.metaform.api.spec.MetaformMemberGroup
     return createOk(metaformMemberGroupTranslator.translate(foundMetaformMemberGroup, foundGroupMembers))
   }
 
-  override suspend fun listMetaformMemberGroups(metaformId: UUID): Response {
+  override fun listMetaformMemberGroups(metaformId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -111,7 +111,7 @@ class MetaformMemberGroupsApi: fi.metatavu.metaform.api.spec.MetaformMemberGroup
     return createOk(metaformMemberGroups)
   }
 
-  override suspend fun updateMetaformMemberGroup(metaformId: UUID, metaformMemberGroupId: UUID, metaformMemberGroup: MetaformMemberGroup): Response {
+  override fun updateMetaformMemberGroup(metaformId: UUID, metaformMemberGroupId: UUID, metaformMemberGroup: MetaformMemberGroup): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformMembersApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformMembersApi.kt
@@ -28,7 +28,7 @@ class MetaformMembersApi: fi.metatavu.metaform.api.spec.MetaformMembersApi, Abst
   @Inject
   lateinit var metaformMemberTranslator: MetaformMemberTranslator
 
-  override suspend fun createMetaformMember(metaformId: UUID, metaformMember: MetaformMember): Response {
+  override fun createMetaformMember(metaformId: UUID, metaformMember: MetaformMember): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -58,7 +58,7 @@ class MetaformMembersApi: fi.metatavu.metaform.api.spec.MetaformMembersApi, Abst
     return createOk(metaformMemberTranslator.translate(createdMetaformMember, metaformMember.role))
   }
 
-  override suspend fun deleteMetaformMember(metaformId: UUID, metaformMemberId: UUID): Response {
+  override fun deleteMetaformMember(metaformId: UUID, metaformMemberId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -81,7 +81,7 @@ class MetaformMembersApi: fi.metatavu.metaform.api.spec.MetaformMembersApi, Abst
     return createNoContent()
   }
 
-  override suspend fun findMetaformMember(metaformId: UUID, metaformMemberId: UUID): Response {
+  override fun findMetaformMember(metaformId: UUID, metaformMemberId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -102,7 +102,7 @@ class MetaformMembersApi: fi.metatavu.metaform.api.spec.MetaformMembersApi, Abst
     return createOk(metaformMemberTranslator.translate(foundMetaformMember, metaformMemberRole))
   }
 
-  override suspend fun listMetaformMembers(metaformId: UUID, role: MetaformMemberRole?): Response {
+  override fun listMetaformMembers(metaformId: UUID, role: MetaformMemberRole?): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -126,7 +126,7 @@ class MetaformMembersApi: fi.metatavu.metaform.api.spec.MetaformMembersApi, Abst
     return createOk(metaformMembers)
   }
 
-  override suspend fun updateMetaformMember(metaformId: UUID, metaformMemberId: UUID, metaformMember: MetaformMember): Response {
+  override fun updateMetaformMember(metaformId: UUID, metaformMemberId: UUID, metaformMember: MetaformMember): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformsApi.kt
@@ -35,7 +35,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
   @Inject
   lateinit var exportThemeController: ExportThemeController
 
-  override suspend fun createMetaform(metaform: Metaform): Response {
+  override fun createMetaform(metaform: Metaform): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdminAny) {
@@ -86,7 +86,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
     }
   }
 
-  override suspend fun deleteMetaform(metaformId: UUID): Response {
+  override fun deleteMetaform(metaformId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -101,7 +101,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
     return createNoContent()
   }
 
-  override suspend fun findMetaform(
+  override fun findMetaform(
     metaformSlug: String?,
     metaformId: UUID?,
     replyId: UUID?,
@@ -145,7 +145,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
     }
   }
 
-  override suspend fun listMetaforms(visibility: MetaformVisibility?, memberRole: MetaformMemberRole?): Response {
+  override fun listMetaforms(visibility: MetaformVisibility?, memberRole: MetaformMemberRole?): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformManagerAny && visibility == MetaformVisibility.PRIVATE) {
@@ -169,7 +169,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
     return createOk(metaforms.map(metaformTranslator::translate))
   }
 
-  override suspend fun updateMetaform(metaformId: UUID, metaform: Metaform): Response {
+  override fun updateMetaform(metaformId: UUID, metaform: Metaform): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val foundMetaform = metaformController.findMetaformById(metaformId)

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformsApi.kt
@@ -36,7 +36,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
   lateinit var exportThemeController: ExportThemeController
 
   override suspend fun createMetaform(metaform: Metaform): Response {
-    loggedUserId ?: return createForbidden(UNAUTHORIZED)
+    val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdminAny) {
       return createForbidden(createNotAllowedMessage(CREATE, METAFORM))
@@ -75,7 +75,8 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
       visibility = metaform.visibility ?: MetaformVisibility.PRIVATE,
       title = metaform.title,
       slug = metaform.slug,
-      data = metaformData
+      data = metaformData,
+      creatorId = userId
     )
 
     return try {
@@ -169,7 +170,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
   }
 
   override suspend fun updateMetaform(metaformId: UUID, metaform: Metaform): Response {
-    loggedUserId ?: return createForbidden(UNAUTHORIZED)
+    val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val foundMetaform = metaformController.findMetaformById(metaformId)
             ?: return createNotFound(createNotFoundMessage(METAFORM, metaformId))
@@ -211,7 +212,8 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
       visibility = metaform.visibility ?: foundMetaform.visibility!!,
       data = data,
       allowAnonymous = metaform.allowAnonymous ?: false,
-      slug = formSlug
+      slug = formSlug,
+      lastModifierId = userId
     )
 
     return try {

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/RepliesApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/RepliesApi.kt
@@ -75,7 +75,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
    * @param replyModeParam Reply mode
    * @return Created reply
    */
-  override suspend fun createReply(
+  override fun createReply(
     metaformId: UUID,
     reply: Reply,
     updateExisting: Boolean?,
@@ -222,7 +222,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
             .associateBy { attachment -> attachment.id.toString() }
   }
 
-  override suspend fun deleteReply(metaformId: UUID, replyId: UUID, ownerKey: String?): Response {
+  override fun deleteReply(metaformId: UUID, replyId: UUID, ownerKey: String?): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val reply = replyController.findReplyById(replyId)
@@ -251,7 +251,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
    * @param metaformId metaform id
    * @param format format
    */
-  override suspend fun export(metaformId: UUID, format: String): Response {
+  override fun export(metaformId: UUID, format: String): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -298,7 +298,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
    * @param replyId reply id
    * @param ownerKey owner key
    */
-  override suspend fun findReply(metaformId: UUID, replyId: UUID, ownerKey: String?): Response {
+  override fun findReply(metaformId: UUID, replyId: UUID, ownerKey: String?): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val metaform = metaformController.findMetaformById(metaformId)
@@ -349,7 +349,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
    * @param latestFirst return the latest result first according to the criteria in orderBy
    * @return list of replies
    */
-  override suspend fun listReplies(
+  override fun listReplies(
     metaformId: UUID,
     userId: UUID?,
     createdBeforeParam: String?,
@@ -438,7 +438,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
             .filter { reply -> permittedResourceIds.contains(reply.resourceId) }
   }
 
-  override suspend fun replyExport(metaformId: UUID, replyId: UUID, format: String): Response {
+  override fun replyExport(metaformId: UUID, replyId: UUID, format: String): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     val reply = replyController.findReplyById(replyId)
@@ -487,7 +487,7 @@ class RepliesApi: fi.metatavu.metaform.api.spec.RepliesApi, AbstractApi() {
    * @param ownerKey owner key
    * @return updated reply
    */
-  override suspend fun updateReply(
+  override fun updateReply(
     metaformId: UUID,
     replyId: UUID,
     reply: Reply,

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/SystemApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/SystemApi.kt
@@ -10,7 +10,7 @@ import javax.ws.rs.core.Response
 @RequestScoped
 @Transactional
 class SystemApi: fi.metatavu.metaform.api.spec.SystemApi, AbstractApi() {
-  override suspend fun ping(): Response {
+  override fun ping(): Response {
     return createOk("pong")
   }
 }

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/VersionsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/VersionsApi.kt
@@ -26,7 +26,7 @@ class VersionsApi: fi.metatavu.metaform.api.spec.VersionsApi, AbstractApi() {
   @Inject
   lateinit var metaformVersionTranslator: MetaformVersionTranslator
 
-  override suspend fun createMetaformVersion(
+  override fun createMetaformVersion(
     metaformId: UUID,
     metaformVersion: MetaformVersion
   ): Response {
@@ -57,7 +57,7 @@ class VersionsApi: fi.metatavu.metaform.api.spec.VersionsApi, AbstractApi() {
     }
   }
 
-  override suspend fun deleteMetaformVersion(metaformId: UUID, versionId: UUID): Response {
+  override fun deleteMetaformVersion(metaformId: UUID, versionId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -79,7 +79,7 @@ class VersionsApi: fi.metatavu.metaform.api.spec.VersionsApi, AbstractApi() {
     return createNoContent()
   }
 
-  override suspend fun findMetaformVersion(metaformId: UUID, versionId: UUID): Response {
+  override fun findMetaformVersion(metaformId: UUID, versionId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {
@@ -103,7 +103,7 @@ class VersionsApi: fi.metatavu.metaform.api.spec.VersionsApi, AbstractApi() {
     }
   }
 
-  override suspend fun listMetaformVersions(metaformId: UUID): Response {
+  override fun listMetaformVersions(metaformId: UUID): Response {
     loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
     if (!isMetaformAdmin(metaformId)) {

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/translate/MetaformTranslator.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/translate/MetaformTranslator.kt
@@ -1,6 +1,7 @@
 package fi.metatavu.metaform.server.rest.translate
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import fi.metatavu.metaform.server.exceptions.MalformedMetaformJsonException
 import fi.metatavu.metaform.server.persistence.model.Metaform
 import java.io.IOException
@@ -23,6 +24,7 @@ class MetaformTranslator {
   @Throws(MalformedMetaformJsonException::class)
   fun translate(entity: Metaform): fi.metatavu.metaform.api.spec.model.Metaform {
     val objectMapper = ObjectMapper()
+    objectMapper.registerModule(JavaTimeModule())
 
     val result = try {
        objectMapper.readValue(entity.data, fi.metatavu.metaform.api.spec.model.Metaform::class.java)
@@ -34,7 +36,11 @@ class MetaformTranslator {
       id = entity.id,
       slug = entity.slug,
       exportThemeId = entity.exportTheme?.id,
-      visibility = entity.visibility
+      visibility = entity.visibility,
+      createdAt = entity.createdAt,
+      modifiedAt = entity.modifiedAt,
+      creatorId = entity.creatorId,
+      lastModifierId = entity.lastModifierId
     )
   }
 }

--- a/src/main/resources/db/changeLog.xml
+++ b/src/main/resources/db/changeLog.xml
@@ -557,6 +557,10 @@
         <constraints nullable="false"/>
       </column>
     </addColumn>
+    <sql>UPDATE metaform SET creatorId = uuid()</sql>
+    <sql>UPDATE metaform SET lastModifierId = uuid()</sql>
+    <sql>UPDATE metaform SET createdAt = now()</sql>
+    <sql>UPDATE metaform SET modifiedAt = now()</sql>
   </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changeLog.xml
+++ b/src/main/resources/db/changeLog.xml
@@ -541,5 +541,22 @@
         <column name="visibility" type="varchar(16)"/>
       </addColumn>
     </changeSet>
+  
+  <changeSet id="metaform-metadata" author="Ville Juutila">
+    <addColumn tableName="metaform">
+      <column name="createdAt" type="datetime(6)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="modifiedat" type="datetime(6)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="creatorid" type="binary(16)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="lastmodifierid" type="binary(16)">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
 
 </databaseChangeLog>

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/tests/DraftTestsIT.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/tests/DraftTestsIT.kt
@@ -50,12 +50,18 @@ class DraftTestsIT : AbstractTest() {
             val draftData: MutableMap<String, Any> = HashMap()
             draftData["text"] = "draft value"
             val createdDraft: Draft = testBuilder.test1.drafts.createDraft(metaform, draftData)
+            println("createdDraft createdAt: ${createdDraft.createdAt}")
+            println("createdDraft modifiedAt: ${createdDraft.modifiedAt}")
+            println(createdDraft)
             Assertions.assertNotNull(createdDraft)
             Assertions.assertNotNull(createdDraft.id)
             Assertions.assertEquals("draft value", createdDraft.data["text"])
             draftData["text"] = "updated value"
             val updatePayload = Draft(draftData, createdDraft.id, createdDraft.createdAt, createdDraft.modifiedAt)
             val updateDraft: Draft = testBuilder.test1.drafts.updateDraft(metaform.id!!, createdDraft.id!!, updatePayload)
+            println("updateDraft createdAt: ${updateDraft.createdAt}")
+            println("updateDraft modifiedAt: ${updateDraft.modifiedAt}")
+            println(updateDraft)
             Assertions.assertNotNull(updateDraft)
             Assertions.assertEquals(createdDraft.id, updateDraft.id)
             Assertions.assertEquals("updated value", updateDraft.data["text"])

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/tests/DraftTestsIT.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/tests/DraftTestsIT.kt
@@ -50,18 +50,12 @@ class DraftTestsIT : AbstractTest() {
             val draftData: MutableMap<String, Any> = HashMap()
             draftData["text"] = "draft value"
             val createdDraft: Draft = testBuilder.test1.drafts.createDraft(metaform, draftData)
-            println("createdDraft createdAt: ${createdDraft.createdAt}")
-            println("createdDraft modifiedAt: ${createdDraft.modifiedAt}")
-            println(createdDraft)
             Assertions.assertNotNull(createdDraft)
             Assertions.assertNotNull(createdDraft.id)
             Assertions.assertEquals("draft value", createdDraft.data["text"])
             draftData["text"] = "updated value"
             val updatePayload = Draft(draftData, createdDraft.id, createdDraft.createdAt, createdDraft.modifiedAt)
             val updateDraft: Draft = testBuilder.test1.drafts.updateDraft(metaform.id!!, createdDraft.id!!, updatePayload)
-            println("updateDraft createdAt: ${updateDraft.createdAt}")
-            println("updateDraft modifiedAt: ${updateDraft.modifiedAt}")
-            println(updateDraft)
             Assertions.assertNotNull(updateDraft)
             Assertions.assertEquals(createdDraft.id, updateDraft.id)
             Assertions.assertEquals("updated value", updateDraft.data["text"])

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/tests/MetaformTestsIT.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/tests/MetaformTestsIT.kt
@@ -308,9 +308,15 @@ class MetaformTestsIT : AbstractTest() {
             val list: MutableList<Metaform> = builder.systemAdmin.metaforms.list().clone().toMutableList()
             val sortedList = list.sortedBy { it.title }
 
-//            assertEquals(metaform1Modified.toString(), sortedList[0].toString())
-//            assertEquals(metaform2Modified.toString(), sortedList[1].toString())
-//            assertEquals(metaform3Modified.toString(), sortedList[2].toString())
+            assertEquals(metaform1Modified.title, sortedList[0].title)
+            assertEquals(metaform1Modified.slug, sortedList[0].slug)
+            assertEquals(metaform1Modified.visibility, sortedList[0].visibility)
+            assertEquals(metaform2Modified.title, sortedList[1].title)
+            assertEquals(metaform2Modified.slug, sortedList[1].slug)
+            assertEquals(metaform2Modified.visibility, sortedList[1].visibility)
+            assertEquals(metaform3Modified.title, sortedList[2].title)
+            assertEquals(metaform3Modified.slug, sortedList[2].slug)
+            assertEquals(metaform3Modified.visibility, sortedList[2].visibility)
 
             builder.systemAdmin.metaforms.assertCount(2, MetaformVisibility.pUBLIC)
             builder.systemAdmin.metaforms.assertCount(1, MetaformVisibility.pRIVATE)
@@ -353,13 +359,11 @@ class MetaformTestsIT : AbstractTest() {
     fun testUpdateMetaform() {
         TestBuilder().use { builder ->
             val metaform: Metaform = builder.systemAdmin.metaforms.createFromJsonFile("simple")
-            println("metaform createdAt: ${metaform.createdAt}")
-            println("metaform modifiedAt: ${metaform.modifiedAt}")
-            Thread.sleep(10000)
+
             val updatePayload = builder.systemAdmin.metaforms.readMetaform("tbnc")
-            val updatedMetaform = builder.systemAdmin.metaforms.updateMetaform(metaform.id!!, updatePayload!!)
-            println("updatedMetaform createdAt: ${updatedMetaform.createdAt}")
-            println("updatedMetaform modifiedAt: ${updatedMetaform.modifiedAt}")
+            builder.systemAdmin.metaforms.updateMetaform(metaform.id!!, updatePayload!!)
+            val updatedMetaform = builder.systemAdmin.metaforms.findMetaform(null, metaform.id, null, null)
+
             assertEquals(metaform.id, updatedMetaform.id)
             assertEquals(MetaformVisibility.pRIVATE, updatedMetaform.visibility)
             assertEquals(1, updatedMetaform.sections!!.size)
@@ -375,7 +379,9 @@ class MetaformTestsIT : AbstractTest() {
             assertNotEquals(updatedMetaform.createdAt, updatedMetaform.modifiedAt)
 
             val updatedMetaformModified = updatedMetaform.copy(visibility = MetaformVisibility.pUBLIC)
-            val updatedMetaform2 = builder.systemAdmin.metaforms.updateMetaform(metaform.id, updatedMetaformModified)
+            builder.systemAdmin.metaforms.updateMetaform(metaform.id, updatedMetaformModified)
+            val updatedMetaform2 = builder.systemAdmin.metaforms.findMetaform(null, metaform.id, null, null)
+
             assertEquals(MetaformVisibility.pUBLIC, updatedMetaform2.visibility)
             assertEquals(updatedMetaform2.createdAt, updatedMetaform.createdAt)
             assertNotEquals(updatedMetaform2.modifiedAt, updatedMetaform.modifiedAt)

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/tests/VersionTestsIT.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/tests/VersionTestsIT.kt
@@ -42,7 +42,6 @@ class VersionTestsIT : AbstractTest() {
             Assertions.assertNotNull(createdVersion.id)
             Assertions.assertEquals(MetaformVersionType.aRCHIVED, createdVersion.type)
             Assertions.assertEquals(versionData, createdVersion.data)
-            println(version)
 
             val foundVersion = testBuilder.systemAdmin.metaformVersions.findVersion(metaform.id, createdVersion.id!!)
             Assertions.assertNotNull(foundVersion)
@@ -62,7 +61,7 @@ class VersionTestsIT : AbstractTest() {
                     data = versionData
             )
 
-            testBuilder.systemAdmin.metaformVersions.assertCreateFailStatus(404, UUID.randomUUID(), version);
+            testBuilder.systemAdmin.metaformVersions.assertCreateFailStatus(404, UUID.randomUUID(), version)
         }
     }
 
@@ -77,7 +76,7 @@ class VersionTestsIT : AbstractTest() {
                     data = versionData
             )
 
-            testBuilder.test1.metaformVersions.assertCreateFailStatus(403, metaform.id!!, version);
+            testBuilder.test1.metaformVersions.assertCreateFailStatus(403, metaform.id!!, version)
         }
     }
 

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/tests/VersionTestsIT.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/tests/VersionTestsIT.kt
@@ -42,6 +42,7 @@ class VersionTestsIT : AbstractTest() {
             Assertions.assertNotNull(createdVersion.id)
             Assertions.assertEquals(MetaformVersionType.aRCHIVED, createdVersion.type)
             Assertions.assertEquals(versionData, createdVersion.data)
+            println(version)
 
             val foundVersion = testBuilder.systemAdmin.metaformVersions.findVersion(metaform.id, createdVersion.id!!)
             Assertions.assertNotNull(foundVersion)


### PR DESCRIPTION
Resolves #199 
Also changes api implementation suspend functions to regular functions since we're not using reactive jax-rs.
It was also found out that our way of handling PUT requests does not work as intended and I will open another issue for that.