### PR TITLE
Renamed metaform-admin role to system-admin

### DIFF
--- a/dev/kc.json
+++ b/dev/kc.json
@@ -61,7 +61,7 @@
       },
       {
         "id": "b87c1a3f-fd65-46e4-bcb3-65c00c335cca",
-        "name": "metaform-admin",
+        "name": "system-admin",
         "composite": false,
         "clientRole": false,
         "containerId": "test-1"
@@ -264,7 +264,7 @@
       "test": [
         {
           "id": "1a142a9e-a309-459e-a689-6b71a68c0910",
-          "name": "metaform-admin",
+          "name": "system-admin",
           "composite": false,
           "clientRole": true,
           "containerId": "62d9ef30-5bce-4468-aa40-7a595eee9f61"

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/AbstractApi.kt
@@ -324,7 +324,7 @@ abstract class AbstractApi {
      *
      * @return whether logged user is realm user
      */
-    protected val isReamUser: Boolean
+    protected val isRealmUser: Boolean
         get() = hasRealmRole(METAFORM_USER_ROLE)
 
     /**
@@ -452,7 +452,7 @@ abstract class AbstractApi {
 
     companion object {
         const val METAFORM_USER_ROLE = "metaform-user"
-        const val SYSTEM_ADMIN_ROLE = "metaform-admin"
+        const val SYSTEM_ADMIN_ROLE = "system-admin"
         const val VIEW_AUDIT_LOGS_ROLE = "metaform-view-all-audit-logs"
         const val UNAUTHORIZED = "Unauthorized"
         const val LIST = "list"

--- a/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformsApi.kt
+++ b/src/main/kotlin/fi/metatavu/metaform/server/rest/MetaformsApi.kt
@@ -38,7 +38,7 @@ class MetaformsApi: fi.metatavu.metaform.api.spec.MetaformsApi, AbstractApi() {
   override fun createMetaform(metaform: Metaform): Response {
     val userId = loggedUserId ?: return createForbidden(UNAUTHORIZED)
 
-    if (!isMetaformAdminAny) {
+    if (!isRealmSystemAdmin) {
       return createForbidden(createNotAllowedMessage(CREATE, METAFORM))
     }
 

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/builder/TestBuilder.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/builder/TestBuilder.kt
@@ -36,7 +36,7 @@ class TestBuilder : AbstractAccessTokenTestBuilder<ApiClient>() {
 
     private var anonymousTokenCached: TestBuilderAuthentication? = null
     private val serverUrl = ConfigProvider.getConfig().getValue("metaforms.keycloak.admin.host", String::class.java)
-    var systemAdmin = createTestBuilderAuthentication("metaform-admin", "test")
+    var systemAdmin = createTestBuilderAuthentication("system-admin", "test")
     var test1 = createTestBuilderAuthentication("test1.realm1", "test")
     var test2 = createTestBuilderAuthentication("test2.realm1", "test")
     var test3 = createTestBuilderAuthentication("test3.realm1", "test")

--- a/src/test/java/fi/metatavu/metaform/server/test/functional/tests/MetaformTestsIT.kt
+++ b/src/test/java/fi/metatavu/metaform/server/test/functional/tests/MetaformTestsIT.kt
@@ -132,7 +132,7 @@ class MetaformTestsIT : AbstractTest() {
         TestBuilder().use { testBuilder ->
             try {
                 testBuilder.permissionTestByScopes(
-                    scope = PermissionScope.METAFORM_ADMIN,
+                    scope = PermissionScope.SYSTEM_ADMIN,
                     apiCaller = { authentication: TestBuilderAuthentication, _: Int ->
                         authentication.metaforms.createFromJsonFile("simple")
                     }

--- a/src/test/resources/kc.json
+++ b/src/test/resources/kc.json
@@ -57,7 +57,7 @@
       "attributes" : { }
     }, {
       "id" : "9a5833f6-751f-414b-ad04-e7f4cbfb5ed4",
-      "name" : "metaform-admin",
+      "name" : "system-admin",
       "composite" : false,
       "clientRole" : false,
       "containerId" : "test-1",
@@ -442,7 +442,7 @@
   }, {
     "id" : "83543c6b-1324-42c6-a4ca-c164a3ade516",
     "createdTimestamp" : 1526144277240,
-    "username" : "metaform-admin",
+    "username" : "system-admin",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : true,
@@ -458,7 +458,7 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "metaform-user", "offline_access", "metaform-admin", "uma_authorization" ],
+    "realmRoles" : [ "metaform-user", "offline_access", "system-admin", "uma_authorization" ],
     "clientRoles" : {
       "account" : [ "manage-account", "view-profile" ]
     },
@@ -1168,13 +1168,13 @@
         }
       }, {
         "id" : "65a1664f-fc6e-4b56-9880-3fe9e2dcff7f",
-        "name" : "metaform-admin",
-        "description" : "metaform-admin",
+        "name" : "system-admin",
+        "description" : "system-admin",
         "type" : "role",
         "logic" : "POSITIVE",
         "decisionStrategy" : "UNANIMOUS",
         "config" : {
-          "roles" : "[{\"id\":\"metaform-admin\",\"required\":true}]"
+          "roles" : "[{\"id\":\"system-admin\",\"required\":true}]"
         }
       }, {
         "id" : "0bd939ad-53c2-4474-9c25-52fde39e1d44",


### PR DESCRIPTION
Resolves #203 
Also according to spec, only system administrators should be allowed to create new Metaforms so this fixes that.